### PR TITLE
Display Calendar in UTC

### DIFF
--- a/_pages/calendar.md
+++ b/_pages/calendar.md
@@ -13,4 +13,4 @@ The project [Code of Conduct](https://www.python.org/psf/conduct/) applies to al
 
 The community calendar below can be manually added to your personal calendar by clicking on the “+” button in the bottom right corner.
 
-<iframe src="https://calendar.google.com/calendar/embed?src=social.scikitlearn%40gmail.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=social.scikitlearn%40gmail.com&ctz=UTC" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This pull request change the calendar time zone to Universal Time.
It fixes #21.