### PR TITLE
Set baseurl to "/" to make CSS / JS loading work under https://blog.scikit-learn.org/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ email: social@scikit-learn.org
 description: "The official blog of scikit-learn, an open source library for machine learning in Python."
 logo: assets/images/scikit-learn-logo.png
 favicon: assets/images/scikit-learn-logo.png
-baseurl: "/blog"
+baseurl: "/"
 url: "https://scikit-learn.org" # the base hostname 
 twitter_username: scikit_learn
 github_username:  scikit-learn


### PR DESCRIPTION
As discussed in #23.

That should fix browsing from https://blog.scikit-learn.org/ .
<del>But that will break browsing from https://scikit-learn.org/blog/ (but maybe we don't care?)</del>

Edit: now https://scikit-learn.org/blog/ automatically redirects to https://blog.scikit-learn.org/.