### PR TITLE
Fix the hostname in the jekyll config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ description: "The official blog of scikit-learn, an open source library for mach
 logo: assets/images/scikit-learn-logo.png
 favicon: assets/images/scikit-learn-logo.png
 baseurl: "/"
-url: "https://scikit-learn.org" # the base hostname 
+url: "https://blog.scikit-learn.org" # the base hostname
 twitter_username: scikit_learn
 github_username:  scikit-learn
 repository: scikit-learn/blog


### PR DESCRIPTION
I forgot to do it when updating the config to use the blog.scikit-learn.org CNAME.

This is needed by @francoisgoupil to setup the RSS / Atom XML feed.