### PR TITLE
Load MathJax only on pages with usemathjax flag

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -7,6 +7,8 @@
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="msapplication-config" content="/assets/images/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
-<script type="text/javascript" id="MathJax-script" async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-</script>
+
+<!-- Load MathJax only in the pages with `usemathjax: true` -->
+{% if page.usemathjax %}
+  <script type="text/javascript" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+{% endif %}


### PR DESCRIPTION
closes #126

In order to load MathJax in a page, the page header (section with the
post information, ie. title, authors, etc) should contain the flag
`usemathjax: true`.