### PR TITLE
Make performance tag consistent: 'performance' >> 'Performance'

### DIFF
--- a/_posts/2022-11-08-pandas-dataframe-output-for-sklearn-transformer.md
+++ b/_posts/2022-11-08-pandas-dataframe-output-for-sklearn-transformer.md
@@ -4,7 +4,7 @@ date: November 8, 2022
 categories:
   - Technical
 tags:
-  - performance
+  - Performance
 featured-image: pandas_output_sklearn_transformers.PNG
 
 postauthors:


### PR DESCRIPTION
There are two tags:  
- performance
- Performance

I am making the words consistent so there is one unique tag.

<img width="736" alt="Screenshot 2025-02-16 at 10 18 20 AM" src="https://github.com/user-attachments/assets/f62085d6-6fe4-404f-a7de-fb079c8e4d71" />
