### PR TITLE
Generate Image Metadata Tag

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -22,6 +22,9 @@ layout: default
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
+    {% if page.featured-image %}<meta property="og:image" content="{{ page.featured-image  | absolute_url }}">{% endif %}
+
+
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}

--- a/_posts/2024-07-24-adam-li-interview.md
+++ b/_posts/2024-07-24-adam-li-interview.md
@@ -5,7 +5,7 @@ categories:
   - Team
 tags:
   - Open Source
-featured-image: adam-li-interview.png
+featured-image: /assets/images/posts_images/adam-li-interview.png
 
 postauthors:
   - name: Reshama Shaikh
@@ -17,7 +17,7 @@ postauthors:
 ---
 
 <div>
-  <img src="/assets/images/posts_images/{{ page.featured-image }}" alt="">
+  <img src="{{ page.featured-image }}" alt="">
   {% include postauthor.html %}
 </div>
 


### PR DESCRIPTION
According to "facebook sharing debugger" developer tool ([link](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fblog.scikit-learn.org%2Fteam%2Fadam-li-interview%2F )), we are missing metadata tag `og:image`.

This PR uses `featured-image` to generate `og:image` tag


